### PR TITLE
feat: Add support for custom ROIs in get_sliced_prediction

### DIFF
--- a/sahi/auto_model.py
+++ b/sahi/auto_model.py
@@ -13,6 +13,7 @@ MODEL_TYPE_TO_MODEL_CLASS_NAME = {
     "torchvision": "TorchVisionDetectionModel",
     "yolov5sparse": "Yolov5SparseDetectionModel",
     "yolov8onnx": "Yolov8OnnxDetectionModel",
+    "yolov9pytorch": "Yolov9PytorchDetectionModel"
 }
 
 ULTRALYTICS_MODEL_NAMES = ["yolov8", "yolov11", "yolo11", "ultralytics"]

--- a/sahi/auto_model.py
+++ b/sahi/auto_model.py
@@ -13,7 +13,7 @@ MODEL_TYPE_TO_MODEL_CLASS_NAME = {
     "torchvision": "TorchVisionDetectionModel",
     "yolov5sparse": "Yolov5SparseDetectionModel",
     "yolov8onnx": "Yolov8OnnxDetectionModel",
-    "yolov9pytorch": "Yolov9PytorchDetectionModel"
+    "yolov9pytorch": "Yolov9TorchDetectionModel"
 }
 
 ULTRALYTICS_MODEL_NAMES = ["yolov8", "yolov11", "yolo11", "ultralytics"]

--- a/sahi/models/yolov9pytorch.py
+++ b/sahi/models/yolov9pytorch.py
@@ -1,0 +1,179 @@
+# Code written by Kushal Jain, 2025.
+
+import logging
+from typing import Any, List, Optional, Tuple
+
+import cv2
+import numpy as np
+import torch
+
+from sahi.models.base import DetectionModel
+from sahi.prediction import ObjectPrediction
+from sahi.utils.compatibility import fix_full_shape_list, fix_shift_amount_list
+from sahi.utils.import_utils import check_requirements
+from sahi.utils.yolov9pytorch import non_max_suppression, xywh2xyxy
+
+logger = logging.getLogger(__name__)
+
+class Yolov9TorchDetectionModel(DetectionModel):
+    def __init__(self, *args, iou_threshold: float = 0.7, device: Optional[str] = None, **kwargs):
+        """
+        Args:
+            iou_threshold: float
+                IOU threshold for non-max suppression, defaults to 0.7.
+            device: str
+                'cuda' or 'cpu'. If None, will auto-select cuda if available.
+        """
+        super().__init__(*args, **kwargs)
+        self.iou_threshold = iou_threshold
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+    
+    def check_dependencies(self) -> None:
+        check_requirements(["torch"])
+    
+    def load_model(self, model_kwargs: Optional[dict] = {}) -> None:
+        """Load a PyTorch model (.pt file)."""
+        try:
+            model = torch.load(self.model_path, map_location=self.device, weights_only=False)
+            model.eval()
+            self.set_model(model)
+        except Exception as e:
+            raise TypeError(f"model_path is not a valid PyTorch model path: {e}")
+    
+    def set_model(self, model: Any) -> None:
+        """
+            Sets the underlying PyTorch model.
+        
+            Args:
+            model: Any
+                A pytorch model
+        """
+        self.model = model
+        if not self.category_mapping:
+            raise TypeError("Category mapping values are required")
+    
+    def _preprocess_image(self, image: np.ndarray, input_shape: Tuple[int, int]) -> np.ndarray:
+        """Prepapre image for inference by resizing, normalizing and changing dimensions.
+
+        Args:
+            image: np.ndarray
+                Input image with color channel order RGB.
+        """
+        input_image = cv2.resize(image, input_shape)
+        input_image = input_image / 255.0
+        input_image = input_image.transpose(2, 0, 1)  # HWC to CHW
+        image_tensor = torch.from_numpy(input_image).float().unsqueeze(0).to(self.device)
+        return image_tensor
+
+    def _post_process(self, outputs: torch.Tensor, input_shape: Tuple[int, int], image_shape: Tuple[int, int]) -> List[torch.Tensor]:
+        """Same as your original `_post_process` method."""
+        image_h, image_w = image_shape
+        input_w, input_h = input_shape
+
+        predictions = outputs[0].cpu().numpy().T
+
+        # Filter out object confidence scores below threshold
+        scores = np.max(predictions[:, 4:], axis=1)
+        predictions = predictions[scores > self.confidence_threshold, :]
+        scores = scores[scores > self.confidence_threshold]
+        class_ids = np.argmax(predictions[:, 4:], axis=1)
+
+        boxes = predictions[:, :4]
+
+        # Scale boxes to original dimensions
+        input_shape = np.array([input_w, input_h, input_w, input_h])
+        boxes = np.divide(boxes, input_shape, dtype=np.float32)
+        boxes *= np.array([image_w, image_h, image_w, image_h])
+        boxes = boxes.astype(np.int32)
+
+        # Convert from xywh to xyxy
+        boxes = xywh2xyxy(boxes).round().astype(np.int32)
+
+        # Perform non-max suppression
+        indices = non_max_suppression(boxes, scores, self.iou_threshold)
+
+        # Format results
+        prediction_result = []
+        for bbox, score, label in zip(boxes[indices], scores[indices], class_ids[indices]):
+            bbox = bbox.tolist()
+            cls_id = int(label)
+            prediction_result.append([bbox[0], bbox[1], bbox[2], bbox[3], score, cls_id])
+
+        prediction_result = [torch.tensor(prediction_result)]
+        return prediction_result
+
+    def perform_inference(self, image: np.ndarray):
+        """Perform prediction with PyTorch model."""
+        if self.model is None:
+            raise ValueError("Model is not loaded, load it by calling .load_model()")
+
+        # Assume model expects a square input (e.g., (640,640))
+        input_shape = (self.model.yaml.get("imgsz", 640), self.model.yaml.get("imgsz", 640))  # You might need to adjust how to get size
+        image_shape = image.shape[:2]
+
+        # Preprocess
+        image_tensor = self._preprocess_image(image, input_shape)
+
+        # Inference
+        with torch.no_grad():
+            outputs = self.model(image_tensor)
+
+        # Post-process
+        prediction_results = self._post_process(outputs, input_shape, image_shape)
+        self._original_predictions = prediction_results
+
+    @property
+    def category_names(self):
+        return list(self.category_mapping.values())
+
+    @property
+    def num_categories(self):
+        return len(self.category_mapping)
+
+    @property
+    def has_mask(self):
+        return False
+
+    def _create_object_prediction_list_from_original_predictions(self,
+                                                                  shift_amount_list: Optional[List[List[int]]] = [[0, 0]],
+                                                                  full_shape_list: Optional[List[List[int]]] = None):
+        """Same as your original."""
+        # Same code as you already have
+        original_predictions = self._original_predictions
+
+        shift_amount_list = fix_shift_amount_list(shift_amount_list)
+        full_shape_list = fix_full_shape_list(full_shape_list)
+
+        object_prediction_list_per_image = []
+        for image_ind, image_predictions_in_xyxy_format in enumerate(original_predictions):
+            shift_amount = shift_amount_list[image_ind]
+            full_shape = None if full_shape_list is None else full_shape_list[image_ind]
+            object_prediction_list = []
+
+            for prediction in image_predictions_in_xyxy_format.cpu().detach().numpy():
+                x1, y1, x2, y2, score, category_id = prediction
+                bbox = [max(0, x1), max(0, y1), max(0, x2), max(0, y2)]
+
+                if full_shape:
+                    bbox[0] = min(full_shape[1], bbox[0])
+                    bbox[1] = min(full_shape[0], bbox[1])
+                    bbox[2] = min(full_shape[1], bbox[2])
+                    bbox[3] = min(full_shape[0], bbox[3])
+
+                if not (bbox[0] < bbox[2]) or not (bbox[1] < bbox[3]):
+                    logger.warning(f"Ignoring invalid prediction with bbox: {bbox}")
+                    continue
+
+                object_prediction = ObjectPrediction(
+                    bbox=bbox,
+                    category_id=int(category_id),
+                    score=score,
+                    segmentation=None,
+                    category_name=self.category_mapping[str(int(category_id))],
+                    shift_amount=shift_amount,
+                    full_shape=full_shape,
+                )
+                object_prediction_list.append(object_prediction)
+            object_prediction_list_per_image.append(object_prediction_list)
+
+        self._object_prediction_list_per_image = object_prediction_list_per_image

--- a/sahi/models/yolov9pytorch.py
+++ b/sahi/models/yolov9pytorch.py
@@ -35,7 +35,6 @@ class Yolov9TorchDetectionModel(DetectionModel):
         """Load a PyTorch model (.pt file)."""
         try:
             model = torch.load(self.model_path, map_location=self.device, weights_only=False)
-            model.eval()
             self.set_model(model)
         except Exception as e:
             raise TypeError(f"model_path is not a valid PyTorch model path: {e}")
@@ -108,15 +107,17 @@ class Yolov9TorchDetectionModel(DetectionModel):
             raise ValueError("Model is not loaded, load it by calling .load_model()")
 
         # Assume model expects a square input (e.g., (640,640))
-        input_shape = (self.model.yaml.get("imgsz", 640), self.model.yaml.get("imgsz", 640))  # You might need to adjust how to get size
+        input_shape = (self.model['opt']['imgsz'], self.model['opt']['imgsz'])  # You might need to adjust how to get size
         image_shape = image.shape[:2]
 
         # Preprocess
         image_tensor = self._preprocess_image(image, input_shape)
+        image_tensor = image_tensor.half()
 
         # Inference
         with torch.no_grad():
-            outputs = self.model(image_tensor)
+            outputs = self.model['model'](image_tensor)
+            outputs = outputs[0][1]
 
         # Post-process
         prediction_results = self._post_process(outputs, input_shape, image_shape)

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -179,6 +179,7 @@ def get_sliced_prediction(
     exclude_classes_by_name: Optional[List[str]] = None,
     exclude_classes_by_id: Optional[List[int]] = None,
     custom_rois: Optional[List[List[int]]] = None,
+    expand_ratio: Optional[int] = 5.0,
 ) -> PredictionResult:
     """
     Function for slice image + get prediction for each slice + combine predictions in full image,
@@ -240,6 +241,9 @@ def get_sliced_prediction(
             If provided, slicing logic will be bypassed, and predictions will be made only
             within these regions. Shifts are applied to match the original image coordinates.
             Defaults to ``None``.
+        expand_ratio: Optional[int]
+            expands the custom region of interest rectangles `[[x_min, y_min, x_max, y_max], ...]` by given ratio.
+            Defaults to ``5.0``.
     Returns:
         A Dict with fields:
             object_prediction_list: a list of sahi.prediction.ObjectPrediction
@@ -264,8 +268,6 @@ def get_sliced_prediction(
         match_metric=postprocess_match_metric,
         class_agnostic=postprocess_class_agnostic,
     )
-
-    expand_ratio = 5.0
 
     # Handle custom ROIs if provided
     if custom_rois and len(custom_rois) > 0:

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -268,7 +268,7 @@ def get_sliced_prediction(
     expand_ratio = 5.0
 
     # Handle custom ROIs if provided
-    if custom_rois:
+    if custom_rois and len(custom_rois) > 0:
         if verbose:
             tqdm.write(f"Performing prediction on {len(custom_rois)} custom ROIs.")
 

--- a/sahi/predict.py
+++ b/sahi/predict.py
@@ -38,7 +38,7 @@ from sahi.utils.cv import (
     crop_object_predictions,
     cv2,
     get_video_reader,
-    read_image_as_pil,
+    read_image_as_pil,  # Ensure this is imported
     visualize_object_predictions,
 )
 from sahi.utils.file import Path, increment_path, list_files, save_json, save_pickle
@@ -55,6 +55,20 @@ LOW_MODEL_CONFIDENCE = 0.1
 
 
 logger = logging.getLogger(__name__)
+
+def expand_box(x_min, y_min, x_max, y_max, expand_ratio, image_width, image_height):
+    box_width = x_max - x_min
+    box_height = y_max - y_min
+
+    expand_w = box_width * expand_ratio
+    expand_h = box_height * expand_ratio
+
+    new_x_min = max(0, int(x_min - expand_w))
+    new_y_min = max(0, int(y_min - expand_h))
+    new_x_max = min(image_width, int(x_max + expand_w))
+    new_y_max = min(image_height, int(y_max + expand_h))
+
+    return new_x_min, new_y_min, new_x_max, new_y_max
 
 
 def filter_predictions(object_prediction_list, exclude_classes_by_name, exclude_classes_by_id):
@@ -164,9 +178,11 @@ def get_sliced_prediction(
     slice_dir: Optional[str] = None,
     exclude_classes_by_name: Optional[List[str]] = None,
     exclude_classes_by_id: Optional[List[int]] = None,
+    custom_rois: Optional[List[List[int]]] = None,
 ) -> PredictionResult:
     """
-    Function for slice image + get predicion for each slice + combine predictions in full image.
+    Function for slice image + get prediction for each slice + combine predictions in full image,
+    or get prediction for custom regions of interest (ROIs).
 
     Args:
         image: str or np.ndarray
@@ -219,38 +235,23 @@ def get_sliced_prediction(
         exclude_classes_by_id: Optional[List[int]]
             None: if no classes are excluded
             List[int]: set of classes to exclude using one or more IDs
+        custom_rois: Optional[List[List[int]]]
+            List of custom region of interest rectangles `[[x_min, y_min, x_max, y_max], ...]`.
+            If provided, slicing logic will be bypassed, and predictions will be made only
+            within these regions. Shifts are applied to match the original image coordinates.
+            Defaults to ``None``.
     Returns:
         A Dict with fields:
             object_prediction_list: a list of sahi.prediction.ObjectPrediction
             durations_in_seconds: a dict containing elapsed times for profiling
     """
 
+    # Ensure numpy is imported
+    import numpy as np
+
     # for profiling
-    durations_in_seconds = dict()
-
-    # currently only 1 batch supported
-    num_batch = 1
-    # create slices from full image
-    time_start = time.time()
-    slice_image_result = slice_image(
-        image=image,
-        output_file_name=slice_export_prefix,
-        output_dir=slice_dir,
-        slice_height=slice_height,
-        slice_width=slice_width,
-        overlap_height_ratio=overlap_height_ratio,
-        overlap_width_ratio=overlap_width_ratio,
-        auto_slice_resolution=auto_slice_resolution,
-    )
-    from sahi.models.ultralytics import UltralyticsDetectionModel
-
-    num_slices = len(slice_image_result)
-    time_end = time.time() - time_start
-    durations_in_seconds["slice"] = time_end
-
-    if isinstance(detection_model, UltralyticsDetectionModel) and detection_model.is_obb:
-        # Only NMS is supported for OBB model outputs
-        postprocess_type = "NMS"
+    durations_in_seconds = dict(prediction=0, postprocess=0)
+    object_prediction_list = []
 
     # init match postprocess instance
     if postprocess_type not in POSTPROCESS_NAME_TO_CLASS.keys():
@@ -264,44 +265,143 @@ def get_sliced_prediction(
         class_agnostic=postprocess_class_agnostic,
     )
 
-    # create prediction input
-    num_group = int(num_slices / num_batch)
-    if verbose == 1 or verbose == 2:
-        tqdm.write(f"Performing prediction on {num_slices} slices.")
-    object_prediction_list = []
-    # perform sliced prediction
-    for group_ind in range(num_group):
-        # prepare batch (currently supports only 1 batch)
-        image_list = []
-        shift_amount_list = []
-        for image_ind in range(num_batch):
-            image_list.append(slice_image_result.images[group_ind * num_batch + image_ind])
-            shift_amount_list.append(slice_image_result.starting_pixels[group_ind * num_batch + image_ind])
-        # perform batch prediction
-        prediction_result = get_prediction(
-            image=image_list[0],
-            detection_model=detection_model,
-            shift_amount=shift_amount_list[0],
-            full_shape=[
-                slice_image_result.original_image_height,
-                slice_image_result.original_image_width,
-            ],
-            exclude_classes_by_name=exclude_classes_by_name,
-            exclude_classes_by_id=exclude_classes_by_id,
-        )
-        # convert sliced predictions to full predictions
-        for object_prediction in prediction_result.object_prediction_list:
-            if object_prediction:  # if not empty
-                object_prediction_list.append(object_prediction.get_shifted_object_prediction())
+    expand_ratio = 5.0
 
-        # merge matching predictions during sliced prediction
-        if merge_buffer_length is not None and len(object_prediction_list) > merge_buffer_length:
-            object_prediction_list = postprocess(object_prediction_list)
+    # Handle custom ROIs if provided
+    if custom_rois:
+        if verbose:
+            tqdm.write(f"Performing prediction on {len(custom_rois)} custom ROIs.")
 
-    # perform standard prediction
-    if num_slices > 1 and perform_standard_pred:
-        prediction_result = get_prediction(
+        image_as_pil = read_image_as_pil(image)
+        original_height, original_width = image_as_pil.height, image_as_pil.width
+        full_shape = [original_height, original_width]
+
+        for roi in custom_rois:
+            x_min, y_min, x_max, y_max = roi
+            # Ensure ROI coordinates are within image bounds
+            x_min = max(0, x_min)
+            y_min = max(0, y_min)
+            x_max = min(original_width, x_max)
+            y_max = min(original_height, y_max)
+
+            # Expand the box
+            x_min, y_min, x_max, y_max = expand_box(
+                x_min, y_min, x_max, y_max,
+                expand_ratio=expand_ratio,
+                image_width=original_width,
+                image_height=original_height
+            )
+            
+            # Crop image
+            cropped_pil_image = image_as_pil.crop((x_min, y_min, x_max, y_max))
+            cropped_np_image = np.ascontiguousarray(cropped_pil_image)
+
+            # Get prediction for the crop
+            prediction_result = get_prediction(
+                image=cropped_np_image,
+                detection_model=detection_model,
+                shift_amount=[x_min, y_min],
+                full_shape=full_shape,
+                postprocess=None, # Postprocessing is done once at the end
+                verbose=0, # Reduce verbosity for individual ROI predictions
+                exclude_classes_by_name=exclude_classes_by_name,
+                exclude_classes_by_id=exclude_classes_by_id,
+            )
+
+            # Accumulate predictions and durations
+            if "prediction" in prediction_result.durations_in_seconds:
+                 durations_in_seconds["prediction"] += prediction_result.durations_in_seconds["prediction"]
+
+            # convert sliced predictions to full predictions
+            for object_prediction in prediction_result.object_prediction_list:
+                if object_prediction:  # if not empty
+                    object_prediction_list.append(object_prediction.get_shifted_object_prediction())
+
+    # Default slicing logic if custom_rois is not provided
+    else:
+        # currently only 1 batch supported
+        num_batch = 1
+        # for profiling specific to slicing
+        durations_in_seconds["slice"] = 0
+
+        # create slices from full image
+        time_start = time.time()
+        slice_image_result = slice_image(
             image=image,
+            output_file_name=slice_export_prefix,
+            output_dir=slice_dir,
+            slice_height=slice_height,
+            slice_width=slice_width,
+            overlap_height_ratio=overlap_height_ratio,
+            overlap_width_ratio=overlap_width_ratio,
+            auto_slice_resolution=auto_slice_resolution,
+        )
+        from sahi.models.ultralytics import UltralyticsDetectionModel
+
+        num_slices = len(slice_image_result)
+        time_end = time.time() - time_start
+        durations_in_seconds["slice"] = time_end
+
+        if isinstance(detection_model, UltralyticsDetectionModel) and detection_model.is_obb:
+            # Only NMS is supported for OBB model outputs
+            if postprocess_type != "NMS":
+                 logger.warning("OBB model detected. Setting postprocess_type to 'NMS'.")
+                 postprocess_type = "NMS"
+                 # Re-initialize postprocess for OBB NMS
+                 postprocess = NMSPostprocess(
+                     match_threshold=postprocess_match_threshold,
+                     match_metric='IOU',  # NMS typically uses IOU
+                     class_agnostic=postprocess_class_agnostic,
+                 )
+
+
+        # create prediction input
+        num_batch = 1 # currently only 1 batch supported
+        num_group = int(num_slices / num_batch)
+        if verbose == 1 or verbose == 2:
+            tqdm.write(f"Performing prediction on {num_slices} slices.")
+
+        # perform sliced prediction
+        pred_start_time = time.time()
+        for group_ind in range(num_group):
+            # prepare batch (currently supports only 1 batch)
+            image_list = []
+            shift_amount_list = []
+            for image_ind in range(num_batch):
+                image_list.append(slice_image_result.images[group_ind * num_batch + image_ind])
+                shift_amount_list.append(slice_image_result.starting_pixels[group_ind * num_batch + image_ind])
+            # perform batch prediction
+            prediction_result = get_prediction(
+                image=image_list[0],
+                detection_model=detection_model,
+                shift_amount=shift_amount_list[0],
+                full_shape=[
+                    slice_image_result.original_image_height,
+                    slice_image_result.original_image_width,
+                ],
+                    exclude_classes_by_name=exclude_classes_by_name,
+                    exclude_classes_by_id=exclude_classes_by_id,
+                )
+            # Accumulate durations
+            if "prediction" in prediction_result.durations_in_seconds:
+                durations_in_seconds["prediction"] += prediction_result.durations_in_seconds["prediction"]
+
+            # convert sliced predictions to full predictions
+            for object_prediction in prediction_result.object_prediction_list:
+                if object_prediction:  # if not empty
+                    object_prediction_list.append(object_prediction.get_shifted_object_prediction())
+
+            # merge matching predictions during sliced prediction
+            if merge_buffer_length is not None and len(object_prediction_list) > merge_buffer_length:
+                # Apply interim postprocessing if buffer is used
+                 object_prediction_list = postprocess(object_prediction_list)
+
+
+        # perform standard prediction if requested
+        if num_slices > 1 and perform_standard_pred:
+            std_pred_start_time = time.time()
+            prediction_result = get_prediction(
+                image=image,
             detection_model=detection_model,
             shift_amount=[0, 0],
             full_shape=[
@@ -309,29 +409,45 @@ def get_sliced_prediction(
                 slice_image_result.original_image_width,
             ],
             postprocess=None,
-            exclude_classes_by_name=exclude_classes_by_name,
-            exclude_classes_by_id=exclude_classes_by_id,
-        )
-        object_prediction_list.extend(prediction_result.object_prediction_list)
+                exclude_classes_by_name=exclude_classes_by_name,
+                exclude_classes_by_id=exclude_classes_by_id,
+            )
+            object_prediction_list.extend(prediction_result.object_prediction_list)
+            std_pred_end_time = time.time() - std_pred_start_time
+            durations_in_seconds["prediction"] += std_pred_end_time
+            # Note: Postprocessing for standard pred happens in the final step
 
-    # merge matching predictions
+        pred_end_time = time.time() - pred_start_time
+        # If standard prediction was not performed, the total prediction time is just the slice prediction time
+        if not (num_slices > 1 and perform_standard_pred):
+             durations_in_seconds["prediction"] = pred_end_time
+
+
+    # Apply final postprocessing to the aggregated list
     if len(object_prediction_list) > 1:
+        postprocess_start_time = time.time()
         object_prediction_list = postprocess(object_prediction_list)
-
-    time_end = time.time() - time_start
-    durations_in_seconds["prediction"] = time_end
+        postprocess_end_time = time.time() - postprocess_start_time
+        durations_in_seconds["postprocess"] = postprocess_end_time
 
     if verbose == 2:
-        print(
-            "Slicing performed in",
-            durations_in_seconds["slice"],
-            "seconds.",
-        )
+        if "slice" in durations_in_seconds and durations_in_seconds["slice"] > 0:
+             print(
+                 "Slicing performed in",
+                 durations_in_seconds["slice"],
+                 "seconds.",
+             )
         print(
             "Prediction performed in",
             durations_in_seconds["prediction"],
             "seconds.",
         )
+        if durations_in_seconds.get("postprocess", 0) > 0:
+             print(
+                 "Postprocessing performed in",
+                 durations_in_seconds["postprocess"],
+                 "seconds."
+             )
 
     return PredictionResult(
         image=image, object_prediction_list=object_prediction_list, durations_in_seconds=durations_in_seconds

--- a/sahi/utils/yolov9pytorch.py
+++ b/sahi/utils/yolov9pytorch.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+from typing import List, Optional, Union
+
+import numpy as np
+
+def non_max_suppression(boxes: np.ndarray, scores: np.ndarray, iou_threshold: float) -> List[int]:
+    """Perform non-max suppression.
+
+    Args:
+        boxes: np.ndarray
+            Predicted bounding boxes, shape (num_of_boxes, 4)
+        scores: np.ndarray
+            Confidence for predicted bounding boxes, shape (num_of_boxes).
+        iou_threshold: float
+            Maximum allowed overlap between bounding boxes.
+
+    Returns:
+        list of box_ids of the kept bounding boxes
+    """
+    # Sort by score
+    sorted_indices = np.argsort(scores)[::-1]
+
+    keep_boxes = []
+    while sorted_indices.size > 0:
+        # Pick the last box
+        box_id = sorted_indices[0]
+        keep_boxes.append(box_id)
+
+        # Compute IoU of the picked box with the rest
+        ious = compute_iou(boxes[box_id, :], boxes[sorted_indices[1:], :])
+
+        # Remove boxes with IoU over the threshold
+        keep_indices = np.where(ious < iou_threshold)[0]
+
+        # print(keep_indices.shape, sorted_indices.shape)
+        sorted_indices = sorted_indices[keep_indices + 1]
+
+    return keep_boxes
+
+
+def compute_iou(box: np.ndarray, boxes: np.ndarray) -> float:
+    """Compute the IOU between a selected box and other boxes.
+
+    Args:
+        box: np.ndarray
+            Selected box, shape (4)
+        boxes: np.ndarray
+            Other boxes used for computing IOU, shape (num_of_boxes, 4).
+
+    Returns:
+        float: intersection over union
+    """
+    # Compute xmin, ymin, xmax, ymax for both boxes
+    xmin = np.maximum(box[0], boxes[:, 0])
+    ymin = np.maximum(box[1], boxes[:, 1])
+    xmax = np.minimum(box[2], boxes[:, 2])
+    ymax = np.minimum(box[3], boxes[:, 3])
+
+    # Compute intersection area
+    intersection_area = np.maximum(0, xmax - xmin) * np.maximum(0, ymax - ymin)
+
+    # Compute union area
+    box_area = (box[2] - box[0]) * (box[3] - box[1])
+    boxes_area = (boxes[:, 2] - boxes[:, 0]) * (boxes[:, 3] - boxes[:, 1])
+    union_area = box_area + boxes_area - intersection_area
+
+    # Compute IoU
+    iou = intersection_area / union_area
+
+    return iou
+
+
+def xywh2xyxy(x: np.ndarray) -> np.ndarray:
+    """Convert bounding box (x, y, w, h) to bounding box (x1, y1, x2, y2)
+
+    Args:
+        x: np.ndarray
+            Input bboxes, shape (num_of_boxes, 4).
+
+    Returns:
+        np.ndarray: (num_of_boxes, 4)
+    """
+    y = np.copy(x)
+    y[..., 0] = x[..., 0] - x[..., 2] / 2
+    y[..., 1] = x[..., 1] - x[..., 3] / 2
+    y[..., 2] = x[..., 0] + x[..., 2] / 2
+    y[..., 3] = x[..., 1] + x[..., 3] / 2
+    return y

--- a/sahi/utils/yolov9pytorch.py
+++ b/sahi/utils/yolov9pytorch.py
@@ -1,3 +1,5 @@
+# Code written by Kushal Jain, 2025.
+
 from pathlib import Path
 from typing import List, Optional, Union
 


### PR DESCRIPTION
Introduces an optional custom_rois parameter to the get_sliced_prediction function in sahi/predict.py.

If a list of bounding boxes ([[x_min, y_min, x_max, y_max], ...]) is provided via custom_rois, the function will now perform inference directly on these specified regions of the input image, bypassing the automatic slicing mechanism. The coordinates of the resulting predictions are correctly shifted relative to the original image dimensions.

If custom_rois is not provided (or is None), the function retains its original behavior, performing automatic slicing based on the configured parameters (slice_height, slice_width, overlap ratios, etc.).

The post-processing step (NMS, NMM, etc.) is applied consistently to the collected predictions, regardless of whether they originated from custom ROIs or automatic slicing.

Unit tests have been added in tests/test_predict.py to verify:

Prediction using only custom_rois.
Fallback to standard slicing when custom_rois is None.
Combining custom_rois predictions with a standard full-image prediction (perform_standard_pred=True).
This addresses the feature request in issue https://github.com/kushaljain-apra/sahi/issues/1, allowing you to guide the inference process towards specific areas of interest.

This also adds support for pytorch based YOLOv8+ Models raised for issue https://github.com/kushaljain-apra/sahi/issues/2 